### PR TITLE
Updated parent pom version to 1.639 - integrate node build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.609</version>
+    <version>1.639</version>
     <relativePath/>
   </parent>
   <artifactId>pipeline-editor</artifactId>


### PR DESCRIPTION
@michaelneale ok to merge this?

This enables running of the `gulp` build when the `mvn` build is run.
