### PR TITLE
Upgrade bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
 work
 node_modules
+node
 src/main/resources/org/jenkinsci/plugins/pipelineeditor/pipelineeditor.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,6 @@ builder.src("src/main/js"); // remove quote when ready to face the pain
 builder.tests('src/test/js');
 
 builder.bundle('src/main/js/pipelineeditor.js')
-  .withExternalModuleMapping('bootstrap-detached', 'bootstrap:bootstrap3')
+  .withExternalModuleMapping('bootstrap-detached', 'bootstrap:bootstrap3', {addDefaultCSS: true})
   .inDir('src/main/resources/org/jenkinsci/plugins/pipelineeditor');
  

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.0.1",
   "devDependencies": {
     "gulp": "^3.9.0",
-    "jenkins-js-builder": "0.0.28",
+    "jenkins-js-builder": "0.0.33",
     "jsdom": "^7.0.2"
   },
   "dependencies": {
     "bootstrap-detached": "^3.3.4-v6",
-    "jenkins-js-modules": "^1.3.0",
+    "jenkins-js-modules": "^1.4.0",
     "moment": "^2.10.6",
     "window-handle": "0.0.6"
   }

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,8 @@
     <dependency>
       <groupId>org.jenkins-ci.ui</groupId>
       <artifactId>bootstrap</artifactId>
-      <version>1.1</version>
+      <version>1.2</version>
+      <type>hpi</type>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.609</version>
+    <version>1.639</version>
     <relativePath/>
   </parent>
   <artifactId>pipeline-editor</artifactId>


### PR DESCRIPTION
@michaelneale yo Mic

On top of PR #2 ....
- Upgrade NPM deps
- Use v1.2 of the bootstrap HPI plugin - changes how the "default" namespaced CSS is added i.e. is only added on request (by adding `{addDefaultCSS: true}` in the `gulpfile.js`).
